### PR TITLE
Add JTAG3 SIB read

### DIFF
--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2334,26 +2334,17 @@ static int jtag3_write_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRME
   } else if (strcmp(mem->desc, "usersig") == 0 ||
              strcmp(mem->desc, "userrow") == 0) {
     cmd[3] = MTYPE_USERSIG;
-  } else if (strcmp(mem->desc, "prodsig") == 0) {
-    cmd[3] = MTYPE_PRODSIG;
   } else if (str_starts(mem->desc, "lock")) {
     cmd[3] = MTYPE_LOCK_BITS;
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
-  } else if (strcmp(mem->desc, "calibration") == 0) {
-    cmd[3] = MTYPE_OSCCAL_BYTE;
-    if (pgm->flag & PGM_FL_IS_DW)
-      unsupp = 1;
-  } else if (strcmp(mem->desc, "signature") == 0) {
-    cmd[3] = MTYPE_SIGN_JTAG;
-    if (pgm->flag & PGM_FL_IS_DW)
-      unsupp = 1;
   }
   // Read-only memories or unsupported by debugWire
-  if(str_eq(mem->desc, "osc16err") || str_eq(mem->desc, "osccal16") ||
-     str_eq(mem->desc, "osc20err") || str_eq(mem->desc, "osccal20") ||
-     str_eq(mem->desc, "prodsig") || str_eq(mem->desc, "sernum") ||
-     str_eq(mem->desc, "sib") || unsupp) {
+  if(str_eq(mem->desc, "calibration") || str_eq(mem->desc, "osc16err") ||
+     str_eq(mem->desc, "osccal16") || str_eq(mem->desc, "osc20err") ||
+     str_eq(mem->desc, "osccal20") || str_eq(mem->desc, "prodsig") ||
+     str_eq(mem->desc, "sernum") || str_eq(mem->desc, "sib") ||
+     str_eq(mem->desc, "signature") || str_eq(mem->desc, "temperature") || unsupp) {
       unsigned char is;
       if(jtag3_read_byte(pgm, p, mem, addr, &is) >= 0 && is == data)
         return 0;

--- a/src/jtag3.c
+++ b/src/jtag3.c
@@ -2173,6 +2173,11 @@ static int jtag3_read_byte(const PROGRAMMER *pgm, const AVRPART *p, const AVRMEM
     if (pgm->flag & PGM_FL_IS_DW)
       unsupp = 1;
   } else if (str_eq(mem->desc, "sib")) {
+    if(addr >= AVR_SIBLEN) {
+      pmsg_error("cannot read byte from %s sib as address 0x%04lx outside range [0, 0x%04x]\n",
+        p->desc, addr, AVR_SIBLEN-1);
+      return -1;
+    }
     if(!*PDATA(pgm)->sib_string) {
       pmsg_error("cannot read byte from %s sib as memory not initialised\n", p->desc);
       return -1;

--- a/src/libavrdude.h
+++ b/src/libavrdude.h
@@ -219,7 +219,7 @@ typedef struct opcode {
 #define HAS_VAREF_ADJ         32
 
 #define AVR_FAMILYIDLEN 7
-#define AVR_SIBLEN 16
+#define AVR_SIBLEN 32
 #define CTL_STACK_SIZE 32
 #define FLASH_INSTR_SIZE 3
 #define EEPROM_INSTR_SIZE 20


### PR DESCRIPTION
Tested with av AVR128DA48 Curiosity Nano board, and works great:

```
$ avrdude -cpkobn_updi -pavr128da48 -Usib:r:-:r -T 'read sib'
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9708 (probably avr128da48)

avrdude: processing -U sib:r:-:r
avrdude: reading sib memory ...
avrdude: writing output file <stdout>

    AVR P:2D:1-3M2 (A6.KV001.0)avrdude: processing -T read sib
Reading | ################################################## | 100% 0.00 s 
0000  20 20 20 20 41 56 52 20  50 3a 32 44 3a 31 2d 33  |    AVR P:2D:1-3|
0010  4d 32 20 28 41 36 2e 4b  56 30 30 31 2e 30 29 00  |M2 (A6.KV001.0).|

avrdude done.  Thank you.
```